### PR TITLE
Remove unrequired mint param

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You can [install](https://github.com/nicklockwood/SwiftFormat#how-do-i-install-i
 # Using Homebrew
 $ brew update && brew install swiftformat
 # Using Mint
-$ mint install nicklockwood/SwiftFormat swiftformat
+$ mint install nicklockwood/SwiftFormat
 ```
 
 ## Configuration


### PR DESCRIPTION
This is no longer needed in Mint, as it reads the executable name from the package 😀
It wasn’t required for macOS anyway as it used to take the repo name by default