### PR TITLE
Fix "File not found" on Windows

### DIFF
--- a/src/SwiftFormatEditProvider.ts
+++ b/src/SwiftFormatEditProvider.ts
@@ -62,13 +62,22 @@ function format(request: {
               ? `${request.formatting.tabSize}`
               : "tabs"
           ];
+
+    // Make the path explicitly absolute when on Windows. If we don't do this,
+    // SwiftFormat will interpret C:\ as relative and put it at the end of
+    // the PWD.
+    let fileName = request.document.fileName;
+    if (process.platform === "win32") {
+      fileName = "/" + fileName;
+    }
+
     const newContents = childProcess.execFileSync(
       swiftFormatPath[0],
       [
         ...swiftFormatPath.slice(1),
         "stdin",
         "--stdinpath",
-        request.document.fileName,
+        fileName,
         ...userDefinedParams.options,
         ...(request.parameters || []),
         ...formattingParameters


### PR DESCRIPTION
This fixes #21 (again?).

As it turns out, the error was due to SwiftFormat taking the path as relative. You can see this here:

```
> swiftformat C:\Users\o_o\Desktop\projects\swift\test\Sources\main.swift
error: File not found at C:/Users/o_o/Desktop/projects/swift/test/Sources/C:/Users/o_o/Desktop/projects/swift/test/Sources/main.swift.
```

My solution was just to put a `/` in front of the path if on Windows. SwiftFormat takes it as absolute and it formats it fine.

Tested on Windows 11.
