### PR TITLE
Add on-type formatting support after hitting "return" on non-empty lines

### DIFF
--- a/src/SwiftFormatEditProvider.ts
+++ b/src/SwiftFormatEditProvider.ts
@@ -105,7 +105,8 @@ function format(request: {
 export class SwiftFormatEditProvider
   implements
     vscode.DocumentRangeFormattingEditProvider,
-    vscode.DocumentFormattingEditProvider
+    vscode.DocumentFormattingEditProvider,
+    vscode.OnTypeFormattingEditProvider
 {
   provideDocumentRangeFormattingEdits(
     document: vscode.TextDocument,
@@ -123,6 +124,18 @@ export class SwiftFormatEditProvider
     document: vscode.TextDocument,
     formatting: vscode.FormattingOptions,
   ) {
+    return format({ document, formatting });
+  }
+  provideOnTypeFormattingEdits(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    ch: string,
+    formatting: vscode.FormattingOptions,
+  ) {
+    // Don't format if user has inserted an empty line
+    if (document.lineAt(position.line).text.trim() === "") {
+      return [];
+    }
     return format({ document, formatting });
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,11 @@ export function activate(context: vscode.ExtensionContext) {
       swiftSelector,
       editProvider,
     );
+    vscode.languages.registerOnTypeFormattingEditProvider(
+      swiftSelector,
+      editProvider,
+      "\n",
+    );
   });
 }
 


### PR DESCRIPTION
Adds on-type formatting support after hitting "return" on non-empty lines.

This looks like this assuming you have the `"editor.formatOnType": true`:


https://github.com/vknabel/vscode-swiftformat/assets/54685446/7c1ce16d-30f7-44ac-97ea-975ac137ce6c

