### PR TITLE
configuration: allow specifying the path to `swift-format`.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,9 +41,15 @@ async function buildSwiftformatIfNeeded() {
   const buildOperations = manifests.map((manifest) => {
     const manifestPath = manifest.fsPath;
     const manifestDir = path.dirname(manifestPath);
-    return promisify(exec)("swift run -c release swiftformat --version", {
-      cwd: manifestDir,
-    });
+    const executable = vscode.workspace.getConfiguration().get("swiftformat.path", undefined);
+    return promisify(exec)(
+      executable
+        ? `${executable} --version`
+        : "swift run -c release swiftformat --version",
+      {
+        cwd: manifestDir
+      }
+    );
   });
   try {
     await vscode.window.withProgress(


### PR DESCRIPTION
This allows the user to specify the location of `swift-format` rather than trying to assume that it should be the one that is found via `Path`.