### PR TITLE
Update SwiftFormatEditProvider.ts

### DIFF
--- a/src/SwiftFormatEditProvider.ts
+++ b/src/SwiftFormatEditProvider.ts
@@ -72,22 +72,18 @@ function format(request: {
       fileName = "/" + fileName;
     }
 
-    const newContents = execShellSync(
-      swiftFormatPath[0],
-      [
-        ...swiftFormatPath.slice(1),
-        "stdin",
-        "--stdinpath",
-        fileName,
-        ...userDefinedParams.options,
-        ...(request.parameters || []),
-        ...formattingParameters,
-      ],
-      {
-        encoding: "utf8",
-        input,
-      },
-    );
+    const shellCommandParameters = [
+      "format",
+      ...userDefinedParams.options,
+      ...(request.parameters || []),
+      ...formattingParameters,
+      fileName,
+    ];
+    const newContents = (0, execShell_1.execShellSync)(swiftFormatPath[0], shellCommandParameters, {
+      encoding: "utf8",
+      input,
+    });
+    
     return newContents !== request.document.getText(request.range)
       ? [
           vscode.TextEdit.replace(

--- a/src/SwiftFormatEditProvider.ts
+++ b/src/SwiftFormatEditProvider.ts
@@ -54,16 +54,7 @@ function format(request: {
     if (!userDefinedParams.hasConfig && Current.config.onlyEnableWithConfig()) {
       return [];
     }
-    const formattingParameters =
-      userDefinedParams.options.indexOf("--indent") !== -1
-        ? []
-        : [
-            "--indent",
-            request.formatting.insertSpaces
-              ? `${request.formatting.tabSize}`
-              : "tabs",
-          ];
-
+   
     // Make the path explicitly absolute when on Windows. If we don't do this,
     // SwiftFormat will interpret C:\ as relative and put it at the end of
     // the PWD.
@@ -76,7 +67,6 @@ function format(request: {
       "format",
       ...userDefinedParams.options,
       ...(request.parameters || []),
-      ...formattingParameters,
       fileName,
     ];
     const newContents = (0, execShell_1.execShellSync)(swiftFormatPath[0], shellCommandParameters, {


### PR DESCRIPTION
when using VSCode fails with an error:
>An unknown error occurred. Command failed: /opt/homebrew/bin/swift-format stdin --stdinpath /Sources/Error.swift --indent 4
Error: Unknown option '--stdinpath' Usage: ...

it seems like swift-format is using the new parameters now, I'm not a real vscode extension developer, just debugged it and this version seems to work :D