### PR TITLE
Quote SwiftFormat path to handle spaces

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
       "stopOnEntry": false,
       "sourceMaps": true,
-      "outFiles": ["${workspaceRoot}/out/src"],
+      "outFiles": ["${workspaceRoot}/out/src/*.js"],
       "preLaunchTask": "npm"
     }
   ]

--- a/src/SwiftFormatEditProvider.ts
+++ b/src/SwiftFormatEditProvider.ts
@@ -73,9 +73,9 @@ function format(request: {
     }
 
     const newContents = execShellSync(
-      swiftFormatPath[0],
+      quotePath(swiftFormatPath[0]),
       [
-        ...swiftFormatPath.slice(1),
+        ...swiftFormatPath.slice(1).map(quotePath),
         "stdin",
         "--stdinpath",
         fileName,
@@ -99,6 +99,14 @@ function format(request: {
   } catch (error) {
     handleFormatError(error, request.document);
     return [];
+  }
+}
+
+function quotePath(path: string): string {
+  if (path.startsWith('"') && path.endsWith('"')) {
+    return path;
+  } else {
+    return `"${path}"`;
   }
 }
 


### PR DESCRIPTION
- Spaces in `swiftformat.exe`'s path were not being handled, so formatting failed when the tool was installed in a path with spaces like `C:\Program Files\nicklockwood\SwiftFormat\usr\bin\swiftformat.exe`. Fixed by quoting path.

- Breakpoints could not be set because `launch.json`'s `outFiles` was incorrect.