### PR TITLE
Handle spaces in path only on Windows

### DIFF
--- a/src/SwiftFormatEditProvider.ts
+++ b/src/SwiftFormatEditProvider.ts
@@ -73,9 +73,9 @@ function format(request: {
     }
 
     const newContents = execShellSync(
-      quotePath(swiftFormatPath[0]),
+      swiftFormatPath[0],
       [
-        ...swiftFormatPath.slice(1).map(quotePath),
+        ...swiftFormatPath.slice(1),
         "stdin",
         "--stdinpath",
         fileName,
@@ -99,14 +99,6 @@ function format(request: {
   } catch (error) {
     handleFormatError(error, request.document);
     return [];
-  }
-}
-
-function quotePath(path: string): string {
-  if (path.startsWith('"') && path.endsWith('"')) {
-    return path;
-  } else {
-    return `"${path}"`;
   }
 }
 

--- a/src/execShell.ts
+++ b/src/execShell.ts
@@ -11,7 +11,7 @@ export function execShellSync(
   options: ExecFileSyncOptionsWithStringEncoding,
 ): string {
   if (os.platform() === "win32") {
-    const result = spawnSync(file, args ?? [], {
+    const result = spawnSync(quotePath(file), args ?? [], {
       ...options,
       encoding: "utf8",
       shell: true,
@@ -22,5 +22,13 @@ export function execShellSync(
     return result.stdout;
   } else {
     return execFileSync(file, args, options);
+  }
+}
+
+function quotePath(path: string): string {
+  if (path.startsWith('"') && path.endsWith('"')) {
+    return path;
+  } else {
+    return `"${path}"`;
   }
 }


### PR DESCRIPTION
Fixes #39 

Handle spaces in path only on Windows to prevent breaking Linux and macOS, because only the Windows code path, which calls spawnSync with shell:true, needs this.