### PR TITLE
Format previous line on 'Enter' key

### DIFF
--- a/src/SwiftFormatEditProvider.ts
+++ b/src/SwiftFormatEditProvider.ts
@@ -132,10 +132,24 @@ export class SwiftFormatEditProvider
     ch: string,
     formatting: vscode.FormattingOptions,
   ) {
-    // Don't format if user has inserted an empty line
-    if (document.lineAt(position.line).text.trim() === "") {
-      return [];
+    // If a new line was entered, format the previous line
+    if (ch === "\n" && position.line > 0) {
+      const previousLine = position.line - 1;
+
+      // If the previous line is empty, formatting is not required
+      if (document.lineAt(previousLine).text.trim() === "") {
+        return [];
+      }
+
+      // Create a range for the previous line and format it
+      const previousLineText = document.lineAt(previousLine).text;
+      const range = new vscode.Range(new vscode.Position(previousLine, 0), new vscode.Position(previousLine, previousLineText.length));
+      return format({
+        document,
+        parameters: ["--fragment", "true"],
+        range,
+        formatting
+      });
     }
-    return format({ document, formatting });
   }
 }


### PR DESCRIPTION
When the 'Enter' key is pressed, format the previous line because the user has usually moved to a new empty line. This is the most common scenario.

Also, format only the previous line instead of the entire document for better performance and because formatting the entire doc may conflict with `"editor.formatOnSaveMode": "modifications"` (See [Only format modified text.](https://code.visualstudio.com/updates/v1_49#_only-format-modified-text))

Previously the entire document was formatted if the new line was non-empty.