### PR TITLE
Ignore non-swiftformat manifests

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,7 +40,7 @@ async function filterManifestsForSwiftformat(manifests: vscode.Uri[]): Promise<v
   const filteredManifests: vscode.Uri[] = [];
   for (const manifest of manifests) {
     const content = await fs.promises.readFile(manifest.fsPath, 'utf8');
-    if (content.includes('name: "swiftformat"')) {
+    if (content.includes('SwiftFormat')) {
       filteredManifests.push(manifest);
     }
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from "vscode";
 import { SwiftFormatEditProvider } from "./SwiftFormatEditProvider";
 import Current from "./Current";
 import { promisify } from "util";
+import * as fs from 'fs';
 import * as path from "path";
 import { exec } from "child_process";
 
@@ -34,16 +35,30 @@ export function activate(context: vscode.ExtensionContext) {
   });
 }
 
+// Find Package.swift file for swiftformat
+async function filterManifestsForSwiftformat(manifests: vscode.Uri[]): Promise<vscode.Uri[]> {
+  const filteredManifests: vscode.Uri[] = [];
+  for (const manifest of manifests) {
+    const content = await fs.promises.readFile(manifest.fsPath, 'utf8');
+    if (content.includes('name: "swiftformat"')) {
+      filteredManifests.push(manifest);
+    }
+  }
+  return filteredManifests;
+}
+
 async function buildSwiftformatIfNeeded() {
   const manifests = await vscode.workspace.findFiles(
     "**/Package.swift",
     "**/.build/**",
     2,
   );
-  if (manifests.length == 0) {
+  const filteredManifests = await filterManifestsForSwiftformat(manifests);
+  if (filteredManifests.length == 0) {
     return;
   }
-  const buildOperations = manifests.map((manifest) => {
+
+  const buildOperations = filteredManifests.map((manifest) => {
     const manifestPath = manifest.fsPath;
     const manifestDir = path.dirname(manifestPath);
     return promisify(exec)("swift run -c release swiftformat --version", {


### PR DESCRIPTION
Currently, any `Package.swift` manifest is assumed to potentially belong to `SwiftFormat`, and is built. This causes unnecessary building and creation of .build directories. Filter to only do this for the `SwiftFormat `manifest.