### PR TITLE
Handle nonzero exit codes as errors

### DIFF
--- a/src/execShell.ts
+++ b/src/execShell.ts
@@ -20,7 +20,7 @@ export function execShellSync(
       throw result.error;
     }
     if (result.status !== 0) {
-      throw new Error(`${file} failed with status ${result.status}.`);
+      throw new Error(`${file} failed with exit code ${result.status}.`);
     }
     return result.stdout;
   } else {

--- a/src/execShell.ts
+++ b/src/execShell.ts
@@ -19,6 +19,9 @@ export function execShellSync(
     if (result.error) {
       throw result.error;
     }
+    if (result.status !== 0) {
+      throw new Error(`${file} failed with status ${result.status}.`);
+    }
     return result.stdout;
   } else {
     return execFileSync(file, args, options);


### PR DESCRIPTION
Currently if `swiftformat.exe` returns a nonzero exit code, `result.error` is not populated so we proceed with formatting using the empty stdout.

After:
![image](https://github.com/vknabel/vscode-swiftformat/assets/2314287/4ea27400-14db-4840-a852-f8fa4aef6a9e)