### PR TITLE
feat: swiftformat.path workspace-local overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ let package = Package(
 | `swiftformat.enable`                      | `Bool`     | `true`             | Whether SwiftFormat should actually do something.                                          |
 | `swiftformat.onlyEnableOnSwiftPMProjects` | `Bool`     | `false`            | Requires and uses a SwiftFormat as SwiftPM dependency. This will cause the extension to build the Swift package upon first launch. |
 | `swiftformat.onlyEnableWithConfig`        | `Bool`     | `false`            | Only format if config present.                                                             |
-| `swiftformat.path`                        | `[String]  or String`            | `swiftformat`                                                                              | The location of the globally installed SwiftFormat (resolved with the current path if only a filename). |
+| `swiftformat.path`                        | `[String]  or String`            | `["/usr/bin/env", "swiftformat"]`                                                        | The location of the installed SwiftFormat (global/workspace-relative). |
 | `swiftformat.options`                     | `[String]` | `[]`               | Additional [options for SwiftFormat](https://github.com/nicklockwood/SwiftFormat#options). |
 | `swiftformat.configSearchPaths`           | `[String]` | `[".swiftformat"]` | Possible paths for SwiftFormat config.                                                     |
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/vknabel/vscode-swiftformat"
   },
-  "version": "1.7.1",
+  "version": "1.7.2",
   "license": "MIT",
   "author": {
     "name": "Valentin Knabel",
@@ -70,7 +70,7 @@
         },
         "swiftformat.path": {
           "description": "The location of your globally installed SwiftFormat.",
-          "scope": "machine",
+          "scope": "machine-overridable",
           "default": [
             "/usr/bin/env",
             "swiftformat"


### PR DESCRIPTION
I'm not sure if it works, so it would be cool if you could check it, but the idea is to resolve relative paths so that users of this extension will be able to set project-specific executables.

Current implementation should try to resolve local path and in case it fails (no matching local path found) it will run fallback logic for the global path.